### PR TITLE
Improvements so we can include as a testing library

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [joplin.core "0.3.6"]
                  [joplin.cassandra "0.3.6"]
                  [witan.gateway.schema "0.1.0-SNAPSHOT"]
-                 [witan.workspace-onyx-plugins "0.1.0-SNAPSHOT" :exclusions [org.onyxplatform/onyx commons-logging]]
+                 [witan.workspace-onyx-plugins "0.1.0" :exclusions [org.onyxplatform/onyx commons-logging]]
                  [com.rpl/specter "0.9.3"]]
   :source-paths ["src"]
   :main witan.workspace.system

--- a/project.clj
+++ b/project.clj
@@ -28,5 +28,6 @@
                        :uberjar-name "witan.workspace-standalone.jar"}
              :dev {:source-paths ["dev"]
                    :dependencies [[org.clojure/tools.namespace "0.2.4"]
-                                  [ring/ring-mock "0.3.0"]]
+                                  [ring/ring-mock "0.3.0"]
+                                  [witan.workspace-api "0.1.5"]]
                    :repl-options {:init-ns user}}})

--- a/project.clj
+++ b/project.clj
@@ -29,5 +29,5 @@
              :dev {:source-paths ["dev"]
                    :dependencies [[org.clojure/tools.namespace "0.2.4"]
                                   [ring/ring-mock "0.3.0"]
-                                  [witan.workspace-api "0.1.5"]]
+                                  [witan.workspace-api "0.1.6"]]
                    :repl-options {:init-ns user}}})

--- a/src/witan/workspace/onyx.clj
+++ b/src/witan/workspace/onyx.clj
@@ -188,14 +188,26 @@
 
 (def onyx-catalog-entry-template
   {:onyx/name :witan/name
-   :onyx/fn :witan/fn
+   :onyx/fn (fn [cat config]
+              (if (contains? config :fn-wrapper)
+                (get config :fn-wrapper)
+                (get cat :witan/fn)))
    :onyx/type (constantly :function)
-   :onyx/params (fn [cat _]
-                  (when (contains? cat :witan/params) [:witan/params]))
+   :onyx/batch-size (fn [_ config]
+                      (get-in config [:batch-settings :onyx/batch-size]))
+   :onyx/params (fn [cat config]
+                  (->> (conj []
+                             (when (contains? config :fn-wrapper) :witan/fn)
+                             (when (contains? cat :witan/params) :witan/params))
+                       (remove nil?)
+                       (vec)
+                       (not-empty)))
+   ;;;;;;;
    :witan/params (fn [cat _]
                    (when (contains? cat :witan/params) (:witan/params cat)))
-   :onyx/batch-size (fn [_ config]
-                      (get-in config [:batch-settings :onyx/batch-size]))})
+   :witan/fn (fn [cat config]
+               (when (contains? config :fn-wrapper)
+                 (:witan/fn cat)))})
 
 (defn witan-catalog->onyx-catalog
   [{:keys [catalog] :as workspace}

--- a/src/witan/workspace/onyx.clj
+++ b/src/witan/workspace/onyx.clj
@@ -206,7 +206,7 @@
                   (->> (conj []
                              (when (contains? config :fn-wrapper) :witan/fn)
                              (when (contains? cat :witan/params) :witan/params))
-                       (remove nil?)
+                       (keep identity)
                        (vec)
                        (not-empty)))
    ;;;;;;;

--- a/src/witan/workspace/onyx.clj
+++ b/src/witan/workspace/onyx.clj
@@ -190,6 +190,10 @@
   {:onyx/name :witan/name
    :onyx/fn :witan/fn
    :onyx/type (constantly :function)
+   :onyx/params (fn [cat _]
+                  (when (contains? cat :witan/params) [:witan/params]))
+   :witan/params (fn [cat _]
+                   (when (contains? cat :witan/params) (:witan/params cat)))
    :onyx/batch-size (fn [_ config]
                       (get-in config [:batch-settings :onyx/batch-size]))})
 
@@ -201,9 +205,9 @@
           #(mapv (fn [cat]
                    (reduce-kv
                     (fn [acc onyx-key getter]
-                      (assoc acc
-                             onyx-key
-                             (getter cat config)))
+                      (if-let [r (getter cat config)]
+                        (assoc acc onyx-key r)
+                        acc))
                     {}
                     onyx-catalog-entry-template))
                  %)))

--- a/src/witan/workspace/onyx.clj
+++ b/src/witan/workspace/onyx.clj
@@ -210,8 +210,7 @@
                        (vec)
                        (not-empty)))
    ;;;;;;;
-   :witan/params (fn [cat _]
-                   (when (contains? cat :witan/params) (:witan/params cat)))
+   :witan/params (fn [cat _] (:witan/params cat))
    :witan/fn (fn [cat config]
                (when (contains? config :fn-wrapper)
                  (:witan/fn cat)))})

--- a/src/witan/workspace/schema.clj
+++ b/src/witan/workspace/schema.clj
@@ -67,7 +67,7 @@
    :witan/version s/Str ;; TODO check semver
    :witan/inputs [Input]
    (s/optional-key :witan/outputs) [Output]
-   (s/optional-key :witan/params) s/Any})
+   (s/optional-key :witan/params) {s/Keyword s/Any}})
 
 (def Workspace
   {:workflow  Workflow

--- a/test/witan/workspace/acceptance/asfr_model.clj
+++ b/test/witan/workspace/acceptance/asfr_model.clj
@@ -41,30 +41,33 @@
                      [:scaling-factors :historic-fertility]
                      [:historic-fertility :out]])
 
-(def all-functions (set witan-workflow))
+(def all-functions (set (flatten witan-workflow)))
 
 (defn create-function
   [kw]
   (let [b (symbol "bundle")]
     `(defn ~(symbol (namespace kw) (name kw))
        [~b]
+       (println ">" ~kw)
        (assoc ~b ~kw true))))
 
-(defn births [bundle] (assoc bundle :births true))
-(defn get-births-data-year [bundle] (assoc bundle :get-births-data-year true))
-(defn births-pool [bundle] (assoc bundle :births-pool true))
-(defn estimated-sya-births-pool [bundle] (assoc bundle :estimated-sya-births-pool true))
-(defn at-risk-this-fert-last-year [bundle] (assoc bundle :at-risk-this-fert-last-year true))
-(defn fert-rate-without-45-49 [bundle] (assoc bundle :fert-rate-without-45-49 true))
-(defn historic-fertility [bundle] (assoc bundle :historic-fertility true))
-(defn fert-rate-with-45-49 [bundle] (assoc bundle :fert-rate-with-45-49 true))
-(defn estimated-sya-births [bundle] (assoc bundle :estimated-sya-births true))
-(defn scaling-factors [bundle] (assoc bundle :scaling-factors true))
-(defn actual-births [bundle] (assoc bundle :actual-births true))
-(defn at-risk-last-birth-year [bundle] (assoc bundle :at-risk-last-birth-year true))
-(defn estimated-births [bundle] (assoc bundle :estimated-births true))
-(defn at-risk-last-fert-last-year [bundle] (assoc bundle :at-risk-last-fert-last-year true))
-(defn at-risk-this-birth-year [bundle] (assoc bundle :at-risk-this-birth-year true))
+(clojure.core/defn births [bundle] (clojure.core/println ">" :births) (clojure.core/assoc bundle :births true))
+(clojure.core/defn get-births-data-year [bundle] (clojure.core/println ">" :get-births-data-year) (clojure.core/assoc bundle :get-births-data-year true))
+(clojure.core/defn births-pool [bundle] (clojure.core/println ">" :births-pool) (clojure.core/assoc bundle :births-pool true))
+(clojure.core/defn estimated-sya-births-pool [bundle] (clojure.core/println ">" :estimated-sya-births-pool) (clojure.core/assoc bundle :estimated-sya-births-pool true))
+(clojure.core/defn at-risk-this-fert-last-year [bundle] (clojure.core/println ">" :at-risk-this-fert-last-year) (clojure.core/assoc bundle :at-risk-this-fert-last-year true))
+(clojure.core/defn fert-rate-without-45-49 [bundle] (clojure.core/println ">" :fert-rate-without-45-49) (clojure.core/assoc bundle :fert-rate-without-45-49 true))
+(clojure.core/defn historic-fertility [bundle] (clojure.core/println ">" :historic-fertility) (clojure.core/assoc bundle :historic-fertility true))
+(clojure.core/defn fert-rate-with-45-49 [bundle] (clojure.core/println ">" :fert-rate-with-45-49) (clojure.core/assoc bundle :fert-rate-with-45-49 true))
+(clojure.core/defn estimated-sya-births [bundle] (clojure.core/println ">" :estimated-sya-births) (clojure.core/assoc bundle :estimated-sya-births true))
+(clojure.core/defn scaling-factors [bundle] (clojure.core/println ">" :scaling-factors) (clojure.core/assoc bundle :scaling-factors true))
+(clojure.core/defn out [bundle] (clojure.core/println ">" :out) (clojure.core/assoc bundle :out true))
+(clojure.core/defn actual-births [bundle] (clojure.core/println ">" :actual-births) (clojure.core/assoc bundle :actual-births true))
+(clojure.core/defn at-risk-last-birth-year [bundle] (clojure.core/println ">" :at-risk-last-birth-year) (clojure.core/assoc bundle :at-risk-last-birth-year true))
+(clojure.core/defn estimated-births [bundle] (clojure.core/println ">" :estimated-births) (clojure.core/assoc bundle :estimated-births true))
+(clojure.core/defn at-risk-last-fert-last-year [bundle] (clojure.core/println ">" :at-risk-last-fert-last-year) (clojure.core/assoc bundle :at-risk-last-fert-last-year true))
+(clojure.core/defn in [bundle] (clojure.core/println ">" :in) (clojure.core/assoc bundle :in true))
+(clojure.core/defn at-risk-this-birth-year [bundle] (clojure.core/println ">" :at-risk-this-birth-year) (clojure.core/assoc bundle :at-risk-this-birth-year true))
 
 (comment "Smash the set of the function names through create-function to get default function defs")
 

--- a/test/witan/workspace/acceptance/asfr_model.clj
+++ b/test/witan/workspace/acceptance/asfr_model.clj
@@ -41,33 +41,30 @@
                      [:scaling-factors :historic-fertility]
                      [:historic-fertility :out]])
 
-(def all-functions (set (flatten witan-workflow)))
+(def all-functions (set witan-workflow))
 
 (defn create-function
   [kw]
   (let [b (symbol "bundle")]
     `(defn ~(symbol (namespace kw) (name kw))
        [~b]
-       (println ">" ~kw)
        (assoc ~b ~kw true))))
 
-(clojure.core/defn births [bundle] (clojure.core/println ">" :births) (clojure.core/assoc bundle :births true))
-(clojure.core/defn get-births-data-year [bundle] (clojure.core/println ">" :get-births-data-year) (clojure.core/assoc bundle :get-births-data-year true))
-(clojure.core/defn births-pool [bundle] (clojure.core/println ">" :births-pool) (clojure.core/assoc bundle :births-pool true))
-(clojure.core/defn estimated-sya-births-pool [bundle] (clojure.core/println ">" :estimated-sya-births-pool) (clojure.core/assoc bundle :estimated-sya-births-pool true))
-(clojure.core/defn at-risk-this-fert-last-year [bundle] (clojure.core/println ">" :at-risk-this-fert-last-year) (clojure.core/assoc bundle :at-risk-this-fert-last-year true))
-(clojure.core/defn fert-rate-without-45-49 [bundle] (clojure.core/println ">" :fert-rate-without-45-49) (clojure.core/assoc bundle :fert-rate-without-45-49 true))
-(clojure.core/defn historic-fertility [bundle] (clojure.core/println ">" :historic-fertility) (clojure.core/assoc bundle :historic-fertility true))
-(clojure.core/defn fert-rate-with-45-49 [bundle] (clojure.core/println ">" :fert-rate-with-45-49) (clojure.core/assoc bundle :fert-rate-with-45-49 true))
-(clojure.core/defn estimated-sya-births [bundle] (clojure.core/println ">" :estimated-sya-births) (clojure.core/assoc bundle :estimated-sya-births true))
-(clojure.core/defn scaling-factors [bundle] (clojure.core/println ">" :scaling-factors) (clojure.core/assoc bundle :scaling-factors true))
-(clojure.core/defn out [bundle] (clojure.core/println ">" :out) (clojure.core/assoc bundle :out true))
-(clojure.core/defn actual-births [bundle] (clojure.core/println ">" :actual-births) (clojure.core/assoc bundle :actual-births true))
-(clojure.core/defn at-risk-last-birth-year [bundle] (clojure.core/println ">" :at-risk-last-birth-year) (clojure.core/assoc bundle :at-risk-last-birth-year true))
-(clojure.core/defn estimated-births [bundle] (clojure.core/println ">" :estimated-births) (clojure.core/assoc bundle :estimated-births true))
-(clojure.core/defn at-risk-last-fert-last-year [bundle] (clojure.core/println ">" :at-risk-last-fert-last-year) (clojure.core/assoc bundle :at-risk-last-fert-last-year true))
-(clojure.core/defn in [bundle] (clojure.core/println ">" :in) (clojure.core/assoc bundle :in true))
-(clojure.core/defn at-risk-this-birth-year [bundle] (clojure.core/println ">" :at-risk-this-birth-year) (clojure.core/assoc bundle :at-risk-this-birth-year true))
+(defn births [bundle] (assoc bundle :births true))
+(defn get-births-data-year [bundle] (assoc bundle :get-births-data-year true))
+(defn births-pool [bundle] (assoc bundle :births-pool true))
+(defn estimated-sya-births-pool [bundle] (assoc bundle :estimated-sya-births-pool true))
+(defn at-risk-this-fert-last-year [bundle] (assoc bundle :at-risk-this-fert-last-year true))
+(defn fert-rate-without-45-49 [bundle] (assoc bundle :fert-rate-without-45-49 true))
+(defn historic-fertility [bundle] (assoc bundle :historic-fertility true))
+(defn fert-rate-with-45-49 [bundle] (assoc bundle :fert-rate-with-45-49 true))
+(defn estimated-sya-births [bundle] (assoc bundle :estimated-sya-births true))
+(defn scaling-factors [bundle] (assoc bundle :scaling-factors true))
+(defn actual-births [bundle] (assoc bundle :actual-births true))
+(defn at-risk-last-birth-year [bundle] (assoc bundle :at-risk-last-birth-year true))
+(defn estimated-births [bundle] (assoc bundle :estimated-births true))
+(defn at-risk-last-fert-last-year [bundle] (assoc bundle :at-risk-last-fert-last-year true))
+(defn at-risk-this-birth-year [bundle] (assoc bundle :at-risk-this-birth-year true))
 
 (comment "Smash the set of the function names through create-function to get default function defs")
 

--- a/test/witan/workspace/acceptance/config.clj
+++ b/test/witan/workspace/acceptance/config.clj
@@ -1,4 +1,5 @@
-(ns witan.workspace.acceptance.config)
+(ns witan.workspace.acceptance.config
+  (:require [witan.workspace-api.onyx :refer [default-fn-wrapper default-pred-wrapper]]))
 
 (def config
   {:env-config {:onyx/tenancy-id "testcluster"

--- a/test/witan/workspace/acceptance/config.clj
+++ b/test/witan/workspace/acceptance/config.clj
@@ -18,4 +18,5 @@
                  :onyx.messaging/backpressure-strategy :high-restart-latency}
    :redis-config {:redis/uri "redis://localhost:6379"}
    :batch-settings {:onyx/batch-size 1
-                    :onyx/batch-timeout 1000}})
+                    :onyx/batch-timeout 1000}
+   :fn-wrapper :witan.workspace-api.onyx/default-wrapper})

--- a/test/witan/workspace/acceptance/config.clj
+++ b/test/witan/workspace/acceptance/config.clj
@@ -19,4 +19,5 @@
    :redis-config {:redis/uri "redis://localhost:6379"}
    :batch-settings {:onyx/batch-size 1
                     :onyx/batch-timeout 1000}
-   :fn-wrapper :witan.workspace-api.onyx/default-wrapper})
+   :fn-wrapper :witan.workspace-api.onyx/default-fn-wrapper
+   :pred-wrapper :witan.workspace-api.onyx/default-pred-wrapper})

--- a/test/witan/workspace/acceptance/onyx_test.clj
+++ b/test/witan/workspace/acceptance/onyx_test.clj
@@ -21,18 +21,6 @@
                                               default-pred-wrapper
                                               kw->fn]]))
 
-#_(defn test-fn-wrapper
-    ([fn segment]
-     ((kw->fn fn) segment))
-    ([fn params segment]
-     ((kw->fn fn) segment params)))
-
-#_(defn test-pred-wrapper
-    ([_ _ segment _ fn]
-     ((kw->fn fn) segment))
-    ([_ _ segment _ fn params]
-     ((kw->fn fn) segment params)))
-
 (defn redis-conn []
   {:spec {:uri (get-in config [:redis-config :redis/uri])}})
 

--- a/test/witan/workspace/function_catalog.clj
+++ b/test/witan/workspace/function_catalog.clj
@@ -17,8 +17,17 @@
    :witan/version "1.0"
    :witan/input-schema {:number s/Num}
    :witan/output-schema {:number s/Num}}
-  [{:keys [number]} _]
+  [{:keys [number] :as x} _]
   {:number (inc number)})
+
+(defworkflowfn inc*
+  "increments a number"
+  {:witan/name :witan.test-funcs/inc*
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num}
+   :witan/output-schema {:foo s/Num}}
+  [{:keys [number]} _]
+  {:foo (inc number)})
 
 (defworkflowfn mul2
   "multiplies a number by 2"
@@ -55,18 +64,18 @@
    :witan/input-schema {:number s/Num
                         :to-add s/Num}
    :witan/output-schema {:number s/Num}}
-  [{:keys [number to-add]}]
+  [{:keys [number to-add]} _]
   {:number (+ number to-add)})
 
 (defworkflowfn add*
   "Adds number and to-add"
   {:witan/name :witan.test-funcs/add
    :witan/version "1.0"
-   :witan/input-schema {:number s/Num
+   :witan/input-schema {:foo s/Num
                         :mult s/Num}
    :witan/output-schema {:number s/Num}}
-  [{:keys [number mult]}]
-  {:number (+ number mult)})
+  [{:keys [foo mult]} _]
+  {:number (+ foo mult)})
 
 (defworkflowfn ->str
   "Converts thing to string"
@@ -74,7 +83,7 @@
    :witan/version "1.0"
    :witan/input-schema {:thing s/Any}
    :witan/output-schema {:out-str s/Any}}
-  [{:keys [thing]}]
+  [{:keys [thing]} _]
   {:out-str (str thing)})
 
 (defn source-data

--- a/test/witan/workspace/function_catalog.clj
+++ b/test/witan/workspace/function_catalog.clj
@@ -1,43 +1,79 @@
 (ns witan.workspace.function-catalog
-  (:require [schema.core :as s]))
+  (:require [schema.core :as s]
+            [witan.workspace-api :refer [defworkflowfn
+                                         defworkflowpred]]))
 
-(defn gte-ten
-  [_ _ {:keys [number] :as msg} _]
+(defworkflowpred gte-ten
+  "true if number is greater than 10"
+  {:witan/name :witan.test-preds/gte-ten
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num}}
+  [{:keys [number] :as msg} _]
   (<= 10 number))
 
-(defn my-inc
-  [{:keys [number] :as msg}]
-  (update msg
-          :number
-          inc))
+(defworkflowfn my-inc
+  "increments a number"
+  {:witan/name :witan.test-funcs/inc
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num}
+   :witan/output-schema {:number s/Num}}
+  [{:keys [number]} _]
+  {:number (inc number)})
 
-(defn mult
-  [{:keys [number] :as msg}]
-  (->
-   msg
-   (assoc :mult 2)
-   (dissoc :number)))
+(defworkflowfn mul2
+  "multiplies a number by 2"
+  {:witan/name :witan.test-funcs/mul2
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num}
+   :witan/output-schema {:number s/Num}}
+  [{:keys [number]} _]
+  {:number (* 2 number)})
 
-(defn sum
-  [{:keys [number mult] :as msg}]
-  (->
-   msg
-   (assoc :number (* number mult))
-   (dissoc :mult)))
+(defworkflowfn mul2*
+  "multiplies a number by 2"
+  {:witan/name :witan.test-funcs/mul2*
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num}
+   :witan/output-schema {:mult s/Num}}
+  [{:keys [number]} _]
+  {:mult (* 2 number)})
 
-(defn mul2
-  [{:keys [number]}]
-  {:number (* number 2)})
-
-(defn mulX
-  [{:keys [number]} {:keys [x]}]
+(defworkflowfn mulX
+  "multiplies a number by X"
+  {:witan/name :witan.test-funcs/mulX
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num}
+   :witan/param-schema {:x s/Num}
+   :witan/output-schema {:number s/Num}}
+  [{:keys [number] :as a} {:keys [x] :as b}]
   {:number (* number x)})
 
-(defn add
+(defworkflowfn add
+  "Adds number and to-add"
+  {:witan/name :witan.test-funcs/add
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num
+                        :to-add s/Num}
+   :witan/output-schema {:number s/Num}}
   [{:keys [number to-add]}]
   {:number (+ number to-add)})
 
-(defn ->str
+(defworkflowfn add*
+  "Adds number and to-add"
+  {:witan/name :witan.test-funcs/add
+   :witan/version "1.0"
+   :witan/input-schema {:number s/Num
+                        :mult s/Num}
+   :witan/output-schema {:number s/Num}}
+  [{:keys [number mult]}]
+  {:number (+ number mult)})
+
+(defworkflowfn ->str
+  "Converts thing to string"
+  {:witan/name :witan.test-funcs/->str
+   :witan/version "1.0"
+   :witan/input-schema {:thing s/Any}
+   :witan/output-schema {:out-str s/Any}}
   [{:keys [thing]}]
   {:out-str (str thing)})
 
@@ -45,65 +81,112 @@
   []
   [{:number 0}])
 
-(defn enough?
-  [{:keys [number]}]
-  (> number 10))
+;; (defn gte-ten
+;;   [_ _ {:keys [number] :as msg} _]
+;;   (<= 10 number))
+
+;; (defn my-inc
+;;   [{:keys [number] :as msg}]
+;;   (println "inc number" number)
+
+;;   (update msg
+;;           :number
+;;           inc))
+
+;; (defn mult
+;;   [{:keys [number] :as msg}]
+;;   (->
+;;    msg
+;;    (assoc :mult 2)
+;;    (dissoc :number)))
+
+;; (defn sum
+;;   [{:keys [number mult] :as msg}]
+;;   (->
+;;    msg
+;;    (assoc :number (* number mult))
+;;    (dissoc :mult)))
+
+;; (defn mul2
+;;   [{:keys [number]}]
+;;   {:number (* number 2)})
+
+;; (defn mulX
+;;   [{:keys [number]} {:keys [x]}]
+;;   (println "mulX number" number "x" x)
+;;   {:number (* number x)})
+
+;; (defn add
+;;   [{:keys [number to-add]}]
+;;   {:number (+ number to-add)})
+
+;; (defn ->str
+;;   [{:keys [thing]}]
+;;   {:out-str (str thing)})
+
+;; (defn source-data
+;;   []
+;;   [{:number 0}])
+
+;; (defn enough?
+;;   [{:keys [number]}]
+;;   (> number 10))
 
 
 #_(def contracts
-  [{:witan/fn      :foo/inc
-    :witan/impl    'witan.workspace.function-catalog/inc*
-    :witan/version "1.0"
-    :witan/params-schema nil
-    :witan/inputs  [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]
-    :witan/outputs [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]}
-   {:witan/fn      :foo/mul2
-    :witan/impl    'witan.workspace.function-catalog/mul2
-    :witan/version "1.0"
-    :witan/params-schema nil
-    :witan/inputs  [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]
-    :witan/outputs [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]}
-   {:witan/fn      :foo/mulX
-    :witan/impl    'witan.workspace.function-catalog/mulX
-    :witan/version "1.0"
-    :witan/params-schema MulXParams
-    :witan/inputs  [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]
-    :witan/outputs [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]}
-   {:witan/fn      :foo/add
-    :witan/impl    'witan.workspace.function-catalog/add
-    :witan/version "1.0"
-    :witan/params-schema nil
-    :witan/inputs  [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}
-                    {:witan/schema       FooNumber
-                     :witan/key          :to-add
-                     :witan/display-name "To add"}]
-    :witan/outputs [{:witan/schema       FooNumber
-                     :witan/key          :number
-                     :witan/display-name "Number"}]}
+    [{:witan/fn      :foo/inc
+      :witan/impl    'witan.workspace.function-catalog/inc*
+      :witan/version "1.0"
+      :witan/params-schema nil
+      :witan/inputs  [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]
+      :witan/outputs [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]}
+     {:witan/fn      :foo/mul2
+      :witan/impl    'witan.workspace.function-catalog/mul2
+      :witan/version "1.0"
+      :witan/params-schema nil
+      :witan/inputs  [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]
+      :witan/outputs [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]}
+     {:witan/fn      :foo/mulX
+      :witan/impl    'witan.workspace.function-catalog/mulX
+      :witan/version "1.0"
+      :witan/params-schema MulXParams
+      :witan/inputs  [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]
+      :witan/outputs [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]}
+     {:witan/fn      :foo/add
+      :witan/impl    'witan.workspace.function-catalog/add
+      :witan/version "1.0"
+      :witan/params-schema nil
+      :witan/inputs  [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}
+                      {:witan/schema       FooNumber
+                       :witan/key          :to-add
+                       :witan/display-name "To add"}]
+      :witan/outputs [{:witan/schema       FooNumber
+                       :witan/key          :number
+                       :witan/display-name "Number"}]}
 
-   {:witan/fn      :foo/->str
-    :witan/impl    'witan.workspace.function-catalog/->str
-    :witan/version "1.0"
-    :witan/inputs  [{:witan/schema       s/Any
-                     :witan/key          :thing
-                     :witan/display-name "The value we want to string-ify"}]
-    :witan/outputs [{:witan/schema       s/Str
-                     :witan/key          :out-str
-                     :witan/display-name "String representation"}]}])
+     {:witan/fn      :foo/->str
+      :witan/impl    'witan.workspace.function-catalog/->str
+      :witan/version "1.0"
+      :witan/inputs  [{:witan/schema       s/Any
+                       :witan/key          :thing
+                       :witan/display-name "The value we want to string-ify"}]
+      :witan/outputs [{:witan/schema       s/Str
+                       :witan/key          :out-str
+                       :witan/display-name "String representation"}]}])
 
 (def catalog [{:witan/name :inc
                :witan/fn :witan.workspace.function-catalog/my-inc
@@ -116,7 +199,7 @@
                :witan/version "1.0"
                :witan/inputs [{:witan/input-src-fn   'witan.workspace.core-test/get-data
                                :witan/input-src-key  1
-                               :witan/input-dest-key :number}]}              
+                               :witan/input-dest-key :number}]}
               {:witan/name :mul2
                :witan/fn :witan.workspace.function-catalog/mul2
                :witan/version "1.0"

--- a/test/witan/workspace/onyx_test.clj
+++ b/test/witan/workspace/onyx_test.clj
@@ -6,10 +6,6 @@
 
 (use-fixtures :once st/validate-schemas)
 
-(defn enough?
-  [x]
-  (< 10 x))
-
 (defn workspace
   [{:keys [workflow contracts catalog] :as raw}]
   (->
@@ -128,7 +124,22 @@
             {:catalog
              (filter #(= :mulx (:witan/name %))
                      fc/catalog)}
-            config)))))
+            config))))
+  (testing "Function wrapper is applied"
+    (is (= {:catalog
+            [{:onyx/name :mulx
+              :onyx/fn   :witan.workspace.function-catalog/test-wrapper
+              :onyx/type :function
+              :onyx/batch-size (batch-size config)
+              :onyx/params [:witan/fn :witan/params]
+              :witan/params {:x 3}
+              :witan/fn :witan.workspace.function-catalog/mulX}]}
+           (o/witan-catalog->onyx-catalog
+            {:catalog
+             (filter #(= :mulx (:witan/name %))
+                     fc/catalog)}
+            (assoc config
+                   :fn-wrapper :witan.workspace.function-catalog/test-wrapper))))))
 
 
 (deftest witan-workspace->onyx-job

--- a/test/witan/workspace/onyx_test.clj
+++ b/test/witan/workspace/onyx_test.clj
@@ -115,6 +115,19 @@
             {:catalog
              (filter #(= :inc (:witan/name %))
                      fc/catalog)}
+            config))))
+  (testing "Function with params gets relabeled"
+    (is (= {:catalog
+            [{:onyx/name :mulx
+              :onyx/fn   :witan.workspace.function-catalog/mulX
+              :onyx/type :function
+              :onyx/batch-size (batch-size config)
+              :witan/params {:x 3}
+              :onyx/params [:witan/params]}]}
+           (o/witan-catalog->onyx-catalog
+            {:catalog
+             (filter #(= :mulx (:witan/name %))
+                     fc/catalog)}
             config)))))
 
 


### PR DESCRIPTION
So, this change enables us to use `defworkflowfn` functions as Onyx functions and `defworkflowpred` predicates as flow condition predicates. In order to achieve this, when running on Onyx, there now needs to be `:fn-wrapper` and `:pred-wrapper` keys in the config map supplied to `workspace->onyx-job`. There are example wrappers included (but commented out) in the test but I've also added 'defaults' (plain passthroughs) to the witan.workspace-api. This also adds parameterization in the Onyx jobs (via workspaces).
